### PR TITLE
Update 2023-11-10 1402H

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -1,13 +1,21 @@
 # CHANGELOGS
 
 ## Table of Contents
-+ [2023-11-09 2149H](#2023-11-09-2149H)
++ [2023-11-09](#2023-11-09)
 
 ## Logs
-### 2023-11-09 2149H
+### 2023-11-09
+#### 2149H
 - New
     + Initial Commit
     - Added new directory 'concepts' in '/' to store all concepts and proofs
         - Added new directory 'linux' in 'concepts' for all Linux-related concepts
-            - Added new directory 'start-gui-apps-with-vnc-from-tty' in 'concepts/linux' about `Starting a Virtual Display with VNC server and GUI applications from TTY`
+            - Added new directory 'start-gui-apps-with-vnc-from-tty' in 'concepts/linux' about 'Starting a Virtual Display with VNC server and GUI applications from TTY'
+
+### 2023-11-10
+#### 1402H
+- New
+    - Added new directory 'start-gui-apps-headless' in 'concepts/linux' about 'Starting a GUI applications as a background process/daemon from TTY'
+- Updates
+    - Updated document 'README.md' in 'concepts/linux/start-gui-apps-with-vnc-from-tty' with a standard example/implementation on how this works
 

--- a/concepts/linux/start-gui-apps-headless/README.md
+++ b/concepts/linux/start-gui-apps-headless/README.md
@@ -1,15 +1,11 @@
-# Starting VNC server with GUI applications as a background process/daemon from the tty
+# Starting GUI applications as a background process/daemon from the tty
 
 ## Information
 ### Description
 ```
 within the tty - start up a GUI application, lets say firefox, in the background as a daemon/process using DISPLAY=:1
 
-then afterwhich, starting up either a VNC server, or a Websocket server (i.e. NoVNC) that will point to that :1 display 
-so that when I access the web/browser-based vnc client, it will go straight into firefox
-so yeah, like as a background process such that when I run it, I will remain in the tty instead of going into the GUI application
-
-the idea is that with this, I can startup as many GUI applications as I need/want as individual "VNC servers" and access them through the web browser
+This will startup the GUI in a Xorg Display Server non-graphical (virtual) framebuffer where the rendering will be performed in the background
 ```
 
 ## Setup
@@ -32,22 +28,14 @@ the idea is that with this, I can startup as many GUI applications as I need/wan
     + [Simple and Functional X Virtual Framebuffer runner script](implementations/start_xvfb.sh)
 
 ### Usage
-- Startup X Virtual Framebuffer (Xvfb) with VNC Server and GUI Applications
+- Basic Xorg Display Server headless startup
     - Startup Virtual Framebuffer
         ```console
-        Xvfb :[display-number] -screen [screen] [resolution ([width]x[height]x[color-depth])] &
+        Xvfb :[display-number] &
         ```
     - Export DISPLAY environment variable to the display number
         ```console
         export DISPLAY=:[display-number]
-        ```
-    - Start VNC server
-        ```console
-        x11vnc -display :[display-number] -rfbport [custom-vnc-server-port] -nopw -xkb -forever -bg
-        ```
-    - Start Websocket server
-        ```console
-        websockify -D --web=[web-vnc-client] [websocket-server-port] [vnc-server-host]:[vnc-server-port]
         ```
     - Post-Setup
         - Ideas

--- a/concepts/linux/start-gui-apps-headless/implementations/Makefile
+++ b/concepts/linux/start-gui-apps-headless/implementations/Makefile
@@ -1,0 +1,31 @@
+# Makefile
+
+## Ingredients/Variables
+src_dir = "."
+src_file = "start_xvfb.sh"
+log_dir = "logs"
+log_out = "out.log"
+log_err = "error.log"
+
+ENV = DISPLAY=":6"
+.DEFAULT_RULES := help
+.PHONY := help kill start
+
+## Rules/Targets
+help:
+	## Display help menu
+	@echo -e "Display Help"
+	@echo -e "kill : Kill all dependencies"
+	@echo -e "start : Begin running script"
+
+kill:
+	@pkill x11vnc
+	@pkill websockify
+	@pkill alacritty
+	@pkill Xvfb
+
+start:
+	@${ENV} ./${src_dir}/${src_file} > ${log_dir}/${log_out} 2> ${log_dir}/${log_err} && \
+		echo -e "[+] Success" || \
+		echo -e "[X] Error"
+

--- a/concepts/linux/start-gui-apps-headless/implementations/start_xvfb.sh
+++ b/concepts/linux/start-gui-apps-headless/implementations/start_xvfb.sh
@@ -1,0 +1,81 @@
+: "
+Test: Starting GUI applications as a background process/daemon from the tty
+
+[Description]
+within the tty - start up a GUI application, lets say firefox, in the background as a daemon/process using DISPLAY=:1
+
+then afterwhich, starting up either a VNC server, or a Websocket server (i.e. NoVNC) that will point to that :1 display 
+so that when I access the web/browser-based vnc client, it will go straight into firefox
+so yeah, like as a background process such that when I run it, I will remain in the tty instead of going into the GUI application
+
+the idea is that with this, I can startup as many GUI applications as I need/want as individual "VNC servers" and access them through the web browser
+
+[Notes and Findings]
+- Framebuffer: A framebuffer is a virtual memory container that will hold display data used to well, display - such as Graphical Environments and/or render them
+"
+
+# Initialize Variables
+declare -A xvfb_Settings=(
+    ## X Virtual Framebuffer settings
+    ["display"]=":6"
+    ["screen"]="0" 
+    ["resolution"]="1920x1080x16"
+)
+APPLICATIONS=("openbox" "alacritty")
+dependencies=(${APPLICATIONS[@]} x11vnc websockify Xvfb)
+
+setup()
+{
+    # Pre-Requisites
+
+    ## Create directories
+    mkdir -p "${PWD}/logs"
+
+    ## Check if application is up
+    for app in "${dependencies[@]}"; do
+        # Get Process ID of current app
+        process_ID=$(pgrep $app)
+        if [[ ! -z "$process_ID" ]]; then
+            # Not Empty
+            ## Force kill the process
+            echo -e "Killing: $app"
+            kill -9 $process_ID
+        fi
+    done
+
+    ## Set DISPLAY Environment Variable
+    echo -e "Setting environment variable DISPLAY..."
+    if [[ ${DISPLAY} != "${xvfb_Settings["display"]}" ]]; then
+        # export DISPLAY=${xvfb_Settings["display"]}
+        export DISPLAY=:6
+    fi
+}
+
+main()
+{
+    # Begin start
+
+    ## Startup X virtual framebuffer
+    echo -e "Starting up X virtual framebuffer..."
+    # Xvfb :6 -screen 0 1024x768x16 &
+    Xvfb ${xvfb_Settings["display"]} -screen ${xvfb_Settings["screen"]} ${xvfb_Settings["resolution"]} &
+
+    echo -e ""
+
+    ## Startup GUI applications in the background of the current X Virtual Framebuffer
+    for i in "${!APPLICATIONS[@]}"; do
+        # Get current app
+        curr_app="${APPLICATIONS[$i]}"
+
+        echo -e "Starting: ${curr_app}"
+
+        # Execute current application in the background of the current X Virtual Framebuffer
+        ${curr_app} &
+    done
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    setup
+    echo -e ""
+    main "$@"
+fi

--- a/concepts/linux/start-gui-apps-headless/template/start_xvfb.sh
+++ b/concepts/linux/start-gui-apps-headless/template/start_xvfb.sh
@@ -1,0 +1,51 @@
+: "
+Test: Starting GUI applications as a background process/daemon from the tty
+
+[Description]
+within the tty - start up a GUI application, lets say firefox, in the background as a daemon/process using DISPLAY=:1
+
+then afterwhich, starting up either a VNC server, or a Websocket server (i.e. NoVNC) that will point to that :1 display 
+so that when I access the web/browser-based vnc client, it will go straight into firefox
+so yeah, like as a background process such that when I run it, I will remain in the tty instead of going into the GUI application
+
+the idea is that with this, I can startup as many GUI applications as I need/want as individual "VNC servers" and access them through the web browser
+
+[Notes and Findings]
+- Framebuffer: A framebuffer is a virtual memory container that will hold display data used to well, display - such as Graphical Environments and/or render them
+"
+
+# Initialize Variables
+APPLICATIONS=("openbox")
+DEPENDENCIES=(${APPLICATIONS[@]} x11vnc websockify Xvfb)
+
+## Set Environment Variable
+export DISPLAY=:6
+
+## Check if dependencies are up
+for pkg in "${DEPENDENCIES[@]}"; do
+    echo -e "$pkg"
+    ### Get process ID
+    process_ID="$(pgrep $pkg)"
+
+    ### Kill application process
+    if [[ ! -z "$process_ID" ]]; then
+        echo -e "Killing: $pkg => $process_ID"
+        kill -9 $process_ID
+    fi
+done
+
+# Begin start
+
+## Startup X virtual framebuffer
+Xvfb :6 -screen 0 1024x768x16 &
+
+## Startup GUI applications in the background of the current X Virtual Framebuffer
+for i in "${!APPLICATIONS[@]}"; do
+    # Get current app
+    curr_app="${APPLICATIONS[$i]}"
+
+    # Execute current application in the background of the current X Virtual Framebuffer
+    ${curr_app} &
+done
+
+


### PR DESCRIPTION
- New 
    - Added new directory 'start-gui-apps-headless' in 'concepts/linux' about 'Starting a GUI applications as a background process/daemon from TTY'
- Updates 
    - Updated document 'README.md' in 'concepts/linux/start-gui-apps-with-vnc-from-tty' with a standard example/implementation on how this works